### PR TITLE
fix: replace toEqual with toMatchObject for resp bodies

### DIFF
--- a/services/authentication-service/src/modules/auth/auth.e2e-spec.ts
+++ b/services/authentication-service/src/modules/auth/auth.e2e-spec.ts
@@ -106,7 +106,8 @@ describe('/auth', () => {
         .post('/auth/login')
         .send(body)
         .expect(201);
-      expect(response.body).toEqual(
+
+      expect(response.body).toMatchObject(
         expect.objectContaining({
           token: expect.any(String),
         }),

--- a/services/character-sheet/src/modules/affiliation/affiliation.e2e-spec.ts
+++ b/services/character-sheet/src/modules/affiliation/affiliation.e2e-spec.ts
@@ -61,7 +61,7 @@ describe('/affiliations', () => {
       .get(`/affiliations/${characterSheet._id}`)
       .expect(200);
 
-    expect(response.body).toEqual(characterSheet.affiliation);
+    expect(response.body).toMatchObject(characterSheet.affiliation);
   });
 
   it('/POST /affiliations/:id', async () => {
@@ -89,7 +89,7 @@ describe('/affiliations', () => {
       .send(body)
       .expect(201);
 
-    expect(response.body).toEqual({
+    expect(response.body).toMatchObject({
       acknowledged: true,
       matchedCount: 1,
       modifiedCount: 1,

--- a/services/character-sheet/src/modules/character-sheet/character-sheet.e2e-spec.ts
+++ b/services/character-sheet/src/modules/character-sheet/character-sheet.e2e-spec.ts
@@ -59,7 +59,10 @@ describe('/character-sheets', () => {
       const response = await supertest(app.getHttpServer())
         .get(`/character-sheets/${v4()}`)
         .expect(404);
-      expect(response.body).toEqual({ message: 'Not Found', statusCode: 404 });
+      expect(response.body).toMatchObject({
+        message: 'Not Found',
+        statusCode: 404,
+      });
     });
 
     it('should find result if exists', async () => {
@@ -74,7 +77,7 @@ describe('/character-sheets', () => {
         .get(`/character-sheets/${characterSheet._id}`)
         .expect(200);
 
-      expect(result.body).toEqual(
+      expect(result.body).toMatchObject(
         expect.objectContaining({
           id: characterSheet._id,
           instanceId: characterSheet.instanceId,
@@ -94,7 +97,7 @@ describe('/character-sheets', () => {
       const response = await supertest(app.getHttpServer())
         .get('/character-sheets/?name=MEEKU_ONI')
         .expect(200);
-      expect(response.body).toEqual([]);
+      expect(response.body).toMatchObject([]);
     });
 
     it('should find result if exists', async () => {
@@ -109,7 +112,7 @@ describe('/character-sheets', () => {
         .get('/character-sheets/?name=JANE')
         .expect(200);
 
-      expect(result.body[0]).toEqual(
+      expect(result.body[0]).toMatchObject(
         expect.objectContaining({
           id: characterSheet._id,
           instanceId: characterSheet.instanceId,
@@ -134,7 +137,7 @@ describe('/character-sheets', () => {
         .delete(`/character-sheets/${characterSheet._id}`)
         .expect(200);
 
-      expect(result.body).toEqual(
+      expect(result.body).toMatchObject(
         expect.objectContaining({
           deleted: true,
           deletedCount: 1,

--- a/services/character-sheet/src/modules/npc/npc.e2e-spec.ts
+++ b/services/character-sheet/src/modules/npc/npc.e2e-spec.ts
@@ -62,7 +62,7 @@ describe('/spawns', () => {
         .send(body)
         .expect(201);
 
-      expect(result.body).toEqual(
+      expect(result.body).toMatchObject(
         expect.objectContaining({
           id: body.id,
           instanceId: body.instanceId,

--- a/services/html-to-pdf/src/module/pdf/pdf.e2e-spec.ts
+++ b/services/html-to-pdf/src/module/pdf/pdf.e2e-spec.ts
@@ -38,7 +38,7 @@ describe('/pdf', () => {
         .expect(200);
 
       expect(response.header['content-type']).toEqual('application/pdf');
-      expect(response.body).toEqual(Buffer.from('Test', 'utf-8'));
+      expect(response.body).toMatchObject(Buffer.from('Test', 'utf-8'));
     });
   });
 
@@ -58,7 +58,7 @@ describe('/pdf', () => {
         .expect(201);
 
       expect(response.header['content-type']).toEqual('application/pdf');
-      expect(response.body).toEqual(Buffer.from('Test', 'utf-8'));
+      expect(response.body).toMatchObject(Buffer.from('Test', 'utf-8'));
     });
 
     it('should render url page to json', async () => {
@@ -78,7 +78,7 @@ describe('/pdf', () => {
       expect(response.header['content-type']).toEqual(
         'application/json; charset=utf-8',
       );
-      expect(response.body).toEqual(
+      expect(response.body).toMatchObject(
         expect.objectContaining({
           content: 'VGVzdA==',
           filename: expect.stringContaining('.pdf'),
@@ -104,7 +104,7 @@ describe('/pdf', () => {
       expect(response.header['content-type']).toEqual(
         'application/json; charset=utf-8',
       );
-      expect(response.body).toEqual(
+      expect(response.body).toMatchObject(
         expect.objectContaining({
           title: 'Example Domain',
         }),
@@ -127,7 +127,7 @@ describe('/pdf', () => {
         .expect(201);
 
       expect(response.header['content-type']).toEqual('application/pdf');
-      expect(response.body).toEqual(Buffer.from('Test', 'utf-8'));
+      expect(response.body).toMatchObject(Buffer.from('Test', 'utf-8'));
     });
 
     it('should render url page to json', async () => {
@@ -148,7 +148,7 @@ describe('/pdf', () => {
       expect(response.header['content-type']).toEqual(
         'application/json; charset=utf-8',
       );
-      expect(response.body).toEqual(
+      expect(response.body).toMatchObject(
         expect.objectContaining({
           content: 'VGVzdA==',
           filename: expect.stringContaining('.pdf'),
@@ -175,7 +175,7 @@ describe('/pdf', () => {
       expect(response.header['content-type']).toEqual(
         'application/json; charset=utf-8',
       );
-      expect(response.body).toEqual(
+      expect(response.body).toMatchObject(
         expect.objectContaining({
           title: 'Example Page',
         }),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* DCO sign all commits.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
