### PR TITLE
Make divider for blurb pair responsive

### DIFF
--- a/clients/design-system/src/components/BlurbPair/BlurbPair.tsx
+++ b/clients/design-system/src/components/BlurbPair/BlurbPair.tsx
@@ -17,11 +17,11 @@ export const BlurbPair = (props: BlurbPairProps) => {
   return (
     <div className={`blurb container`}>
       <div className={`row gx-5`}>
-        <div className="blurb-pair-left col border-end border-1 p-5 text-left">
+        <div className="blurb-pair-left col-12 col-md-6 border-end border-1 p-5 text-left">
           <FontAwesomeIcon icon={iconLeft} size={'6x'} className="icon"/>
           <p className="lead mt-4" dangerouslySetInnerHTML={{ __html: xss(textLeft) }} />
         </div>
-        <div className="blurb-pair-right col border-start border-1 p-5 text-left">
+        <div className="blurb-pair-right col-12 col-md-6 border-start border-1 p-5 text-left">
           <FontAwesomeIcon icon={iconRight} size={'6x'} className="icon"/>
           <p className="lead mt-4" dangerouslySetInnerHTML={{ __html: xss(textRight) }} />
         </div>

--- a/clients/design-system/src/components/BlurbPair/style.module.scss
+++ b/clients/design-system/src/components/BlurbPair/style.module.scss
@@ -1,15 +1,22 @@
 @import '../../styles/utils/color-pallette';
+// @import "bootstrap/scss/variables";
+// @import "bootstrap/scss/mixins/_breakpoints.scss";
+
+
+@import "bootstrap/scss/bootstrap";
 
 .blurb {
-  .blurb-pair-left {
-    .icon {
-      color: $color-light-green !important;
-      opacity: 0.618;
+  @include media-breakpoint-down(md) {
+    .blurb-pair-left, .blurb-pair-right {
+      &.border-end, &.border-start {
+        border: none !important;
+      }
     }
   }
+  .blurb-pair-left,
   .blurb-pair-right {
     .icon {
-      color: $color-dark-purple !important;
+      color: $color-light-green !important;
       opacity: 0.618;
     }
   }


### PR DESCRIPTION
This pull request adds responsiveness to the divider for the blurb pair component. The left and right columns now have a responsive layout on smaller screens, ensuring a better user experience.