### PR TITLE
"Add action effects and update attribute enums"

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1976,6 +1976,9 @@ importers:
       express:
         specifier: 4.19.2
         version: 4.19.2
+      luxon:
+        specifier: ~3.3.0
+        version: 3.3.0
       node-cache:
         specifier: 5.1.2
         version: 5.1.2
@@ -2022,6 +2025,9 @@ importers:
       '@types/jest':
         specifier: 29.5.12
         version: 29.5.12
+      '@types/luxon':
+        specifier: ~3.2.0
+        version: 3.2.0
       '@types/node':
         specifier: 20.11.25
         version: 20.11.25

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "8bdd1883a0ff84f2f6d0faf0a3313b138380bc88",
+  "pnpmShrinkwrapHash": "c3a79efdf91e022f924a84892449208f8be54ab6",
   "preferredVersionsHash": "a48003cf229dd47d077bcf6301ac15a6f90e1c34"
 }

--- a/services/character-sheet/package.json
+++ b/services/character-sheet/package.json
@@ -46,7 +46,8 @@
     "reflect-metadata": "0.1.13",
     "rxjs": "7.8.1",
     "source-map-support": "~0.5.21",
-    "uuid": "~9.0.1"
+    "uuid": "~9.0.1",
+    "luxon": "~3.3.0"
   },
   "devDependencies": {
     "@cats-cradle/create-artifact": "2.0.7",
@@ -74,6 +75,7 @@
     "@cats-cradle/create-bundle": "1.0.12",
     "@shelf/jest-mongodb": "~4.2.0",
     "mongodb-memory-server-global": "8.13.0",
-    "mongoose": "6.11.3"
+    "mongoose": "6.11.3",
+    "@types/luxon": "~3.2.0"
   }
 }

--- a/services/character-sheet/src/data/attribute.ts
+++ b/services/character-sheet/src/data/attribute.ts
@@ -1,24 +1,19 @@
 /*
- * Attributes are the primary way to describe a character's **last known state**.
+ * Gauge attributes
+ * Gauges have a current value and a maximum value.
+ * The maximum value may be exceeded, but the current value cannot be negative.
+ * The current value is variable, and may be modified by actions.
+ * The maximum value is fixed, and cannot be modified by actions. Instead it is computed from the
+ * character's discipline, the character's level, and the character's equipment.
+ * https://en.wikipedia.org/wiki/Attribute_(role-playing_games)
  */
-export enum Attribute {
-  /** Character Attributes */
-  EXPERIENCE = 'Experience',
-
-  /*
-   * Gauge attributes
-   * Gauges have a current value and a maximum value.
-   * The maximum value may be exceeded, but the current value cannot be negative.
-   * The current value is variable, and may be modified by actions.
-   * The maximum value is fixed, and cannot be modified by actions. Instead it is computed from the
-   * character's discipline, the character's level, and the character's equipment.
-   * https://en.wikipedia.org/wiki/Attribute_(role-playing_games)
-   */
+export enum GaugeAttribute {
   LIFE = 'Life',
   SPIRIT = 'Spirit',
   DRIVE = 'Drive',
+}
 
-  /** Base Attributes */
+export enum BaseAttribute {
   POWER = 'Power',
   SPEED = 'Speed',
   WISDOM = 'Wisdom',
@@ -27,4 +22,26 @@ export enum Attribute {
   ACCURACY = 'Accuracy',
   EVASION = 'Evasion',
   LUCK = 'Luck',
+}
+
+export enum CharacterAttribute {
+  EXPERIENCE = 'Experience',
+}
+
+/*
+ * Attributes are metrics that describe a character's **last known state**.
+ */
+export enum Attribute {
+  LIFE = 'Life',
+  SPIRIT = 'Spirit',
+  DRIVE = 'Drive',
+  POWER = 'Power',
+  SPEED = 'Speed',
+  WISDOM = 'Wisdom',
+  INTELLIGENCE = 'Intelligence',
+  DEFENSE = 'Defense',
+  ACCURACY = 'Accuracy',
+  EVASION = 'Evasion',
+  LUCK = 'Luck',
+  EXPERIENCE = 'Experience',
 }

--- a/services/character-sheet/src/data/skill/drive.skill.ts
+++ b/services/character-sheet/src/data/skill/drive.skill.ts
@@ -1,6 +1,8 @@
 // category: SkillCategory.DRIVE;
 
+import { Duration } from 'luxon';
 import { MenuSlot } from '../menu-slot';
+import { ActionEffects } from '../table.effect';
 
 /**
  * Drive Actions are special actions that consume drive gauge
@@ -11,18 +13,39 @@ export namespace Drive {
     description: string;
     conditions?: string;
     menuSlot: MenuSlot;
+    actionEffects?: ActionEffects;
   };
 
   export const BERSERK: Type = {
     name: 'Berserk',
     description: 'Become completely focused on winning',
     menuSlot: MenuSlot.THIRD,
+    actionEffects: {
+      CASTER: [
+        {
+          add: 'BERSERK',
+          chance: 1.0,
+          duration: Duration.fromObject({ minutes: 5 }),
+          tags: [],
+        },
+      ],
+    },
   };
 
   export const TOXIC_THRUST: Type = {
     name: 'Toxic Thrust',
     description: '',
     menuSlot: MenuSlot.THIRD,
+    actionEffects: {
+      OPPONENT: [
+        {
+          add: 'POISON',
+          chance: 1.0,
+          duration: Duration.fromObject({ minutes: 20 }),
+          tags: [],
+        },
+      ],
+    },
   };
 
   export const AERIAL_ASSUALT: Type = {
@@ -35,6 +58,16 @@ export namespace Drive {
     name: 'Oni',
     description: `Become engulfed in a blood thirsty rage that multiplies your power but drains spirit.
       If character stays in Oni too long they will go Berserk`,
+    actionEffects: {
+      CASTER: [
+        {
+          add: 'ONI',
+          chance: 1.0,
+          duration: Duration.fromObject({ minutes: 3 }),
+          tags: [],
+        },
+      ],
+    },
     menuSlot: MenuSlot.THIRD,
   };
 

--- a/services/character-sheet/src/data/skill/passive.skill.ts
+++ b/services/character-sheet/src/data/skill/passive.skill.ts
@@ -1,4 +1,6 @@
+import { Attribute } from '../attribute';
 import { MenuSlot } from '../menu-slot';
+import { EffectTable } from '../table.effect';
 
 /**
  * Passive skills are innate abilities or enhancements possessed by characters
@@ -14,6 +16,8 @@ export namespace Passive {
     name: string;
     description: string;
     menuSlot: MenuSlot;
+    effect?: EffectTable;
+    cost?: null;
   };
 
   export const DUAL_WELD: Type = {
@@ -64,20 +68,35 @@ export namespace Passive {
   export const SLOTH_COMPOSURE: Type = {
     name: 'Sloth Composure',
     description: 'Halves damage taken when not actively engaged in actions.',
+    // halfs damage and decreases DRIVE gauge
     // Acquired by defeating Lawzon.
     menuSlot: MenuSlot.NONE,
   };
 
   export const BLOOD_LUST: Type = {
     name: 'Blood Lust',
-    description: 'Increases speed during battles.',
+    description: 'Increases speed.',
+    effect: [
+      {
+        add: Attribute.SPEED,
+        quantity: '10',
+        chance: 1.0,
+      },
+    ],
     // Acquired by defeating Lust.
     menuSlot: MenuSlot.NONE,
   };
 
   export const ENVIOUS_OF_COMBAT: Type = {
     name: 'Envious of Combat',
-    description: 'Gains rage passively from observing combat.',
+    description: 'Gains increased power.',
+    effect: [
+      {
+        add: Attribute.POWER,
+        quantity: '10',
+        chance: 1.0,
+      },
+    ],
     // Acquired by defeating Envy.
     menuSlot: MenuSlot.NONE,
   };
@@ -85,6 +104,14 @@ export namespace Passive {
   export const GLUTTONOUS_DESIRE: Type = {
     name: 'Gluttonous Desire',
     description: 'Consumes food items twice as fast.',
+    effect: [
+      {
+        add: Attribute.LIFE,
+        quantity: '10',
+        chance: 1.0,
+      },
+      // TODO add effect for consuming food
+    ],
     // Acquired by defeating Gluttony.
     menuSlot: MenuSlot.NONE,
   };
@@ -92,6 +119,12 @@ export namespace Passive {
   export const CATCHER: Type = {
     name: 'Catcher',
     description: 'Receives bonuses when catching items.',
+    menuSlot: MenuSlot.NONE,
+  };
+
+  export const LIMITLESS: Type = {
+    name: 'Limitless',
+    description: 'Higher level cap.',
     menuSlot: MenuSlot.NONE,
   };
 }

--- a/services/character-sheet/src/data/status-effect.ts
+++ b/services/character-sheet/src/data/status-effect.ts
@@ -130,6 +130,12 @@ export namespace StatusEffect {
     category: StatusEffectCategory.AFFLICTION,
   };
 
+  export const POISON: BaseType = {
+    name: 'Posion',
+    description: 'Damage is received each turn until healed.',
+    category: StatusEffectCategory.AFFLICTION,
+  };
+
   export const METAMORPHIC: BaseType = {
     name: 'Metamorphic',
     description: 'You are inflicted with random status affect each turn.',
@@ -203,8 +209,8 @@ export namespace StatusEffect {
     category: StatusEffectCategory.BUFF,
   };
 
-  export const OMNI: BaseType = {
-    name: 'Omni',
+  export const ONI: BaseType = {
+    name: 'Oni',
     description: 'enters a berserk like mode and attacks uncontrollable.',
     category: StatusEffectCategory.BUFF,
   };

--- a/services/character-sheet/src/data/table.effect.ts
+++ b/services/character-sheet/src/data/table.effect.ts
@@ -1,7 +1,9 @@
+import { Duration } from 'luxon';
 import { SkillType } from './skill';
 import { EffectTag } from './tag.effect';
 import { StatusEffectId } from './status-effect';
 import { Attribute } from './attribute';
+import { Target } from './target.effect';
 
 export enum Modifier {
   ADD = 'ADD',
@@ -22,6 +24,7 @@ export interface AttributeAddEffectRecord {
   add: Attribute;
   quantity: string;
   chance?: number;
+  duration?: Duration;
   tags?: Array<EffectTag>;
 }
 
@@ -32,6 +35,7 @@ export interface AttributeRemoveEffectRecord {
   tags?: Array<EffectTag>;
 }
 
+// TODO should this have an add and remove and duration?
 export interface SkillEffectRecord {
   skill: SkillType;
   modifier: SkillEffectModifier;
@@ -41,6 +45,7 @@ export interface SkillEffectRecord {
 export interface StatusEffectAddRecord {
   add: StatusEffectId;
   chance?: number;
+  duration?: Duration;
   tags?: Array<EffectTag>;
 }
 
@@ -63,3 +68,11 @@ export type EffectRecord =
  * A representation of the effect of an action
  */
 export type EffectTable = EffectRecord[];
+
+/**
+ * Represents the effects of an action on different targets.
+ * Each target is mapped to an array of EffectRecords capturing the effects.
+ */
+export type ActionEffects = {
+  [key in Target]?: EffectRecord[];
+};


### PR DESCRIPTION
This pull request adds action effects to the Drive actions, allowing them to apply status effects to the caster and opponent. It also updates the attribute enums to include gauge attributes and separates them from the base attributes.